### PR TITLE
[feat]get store

### DIFF
--- a/src/store/repository/prisma/prismaStore.repository.spec.ts
+++ b/src/store/repository/prisma/prismaStore.repository.spec.ts
@@ -16,6 +16,7 @@ describe('PrismaStoreRepository', () => {
           useValue: {
             store: {
               create: jest.fn(),
+              findFirst: jest.fn(),
             },
           },
         },
@@ -52,5 +53,29 @@ describe('PrismaStoreRepository', () => {
       createdAt: expect.any(String),
       updatedAt: expect.any(String),
     });
+  });
+
+  it('should find store by id and userId', async () => {
+    const mockStoreId = randomUUID();
+    const mockUserId = randomUUID();
+    const mockStore = {
+      id: mockStoreId,
+      name: 'Store',
+      userId: mockUserId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    jest
+      .spyOn<any, any>(mockPrismaService.store, 'findFirst')
+      .mockImplementation(() => Promise.resolve(mockStore));
+
+    const store = await repository.get(mockUserId, mockStoreId);
+    expect(mockPrismaService.store.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: mockStoreId,
+        userId: mockUserId,
+      },
+    });
+    expect(store).toMatchObject(mockStore);
   });
 });

--- a/src/store/repository/prisma/prismaStore.repository.ts
+++ b/src/store/repository/prisma/prismaStore.repository.ts
@@ -10,4 +10,7 @@ export class PrismaStoreRepository implements StoreRepository {
 
   create = async (newStore: NewStoreModel): Promise<Store> =>
     this.prisma.store.create({ data: newStore });
+
+  get = async (userId: string, storeId: string): Promise<Store> =>
+    this.prisma.store.findFirst({ where: { id: storeId, userId } });
 }

--- a/src/store/repository/store.repository.ts
+++ b/src/store/repository/store.repository.ts
@@ -3,4 +3,6 @@ import { NewStoreModel } from '../model/new-store.model';
 
 export abstract class StoreRepository {
   create: (newStore: NewStoreModel) => Promise<Store>;
+
+  get: (userId: string, storeId: string) => Promise<Store>;
 }

--- a/src/store/service/store.service.ts
+++ b/src/store/service/store.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { NewStoreModel } from '../model/new-store.model';
 import { StoreRepository } from '../repository/store.repository';
 import { Store } from '@prisma/client';
@@ -8,4 +8,14 @@ export class StoreService {
   constructor(private readonly storeRepository: StoreRepository) {}
   create = async (newStore: NewStoreModel): Promise<Store> =>
     this.storeRepository.create(newStore);
+
+  get = async (userId: string, storeId: string): Promise<Store> => {
+    const store = await this.storeRepository.get(userId, storeId);
+
+    if (!store) {
+      throw new NotFoundException('Store not found');
+    }
+
+    return store;
+  };
 }

--- a/src/user/service/user.service.spec.ts
+++ b/src/user/service/user.service.spec.ts
@@ -15,6 +15,7 @@ describe('UsersService', () => {
           provide: StoreService,
           useValue: {
             create: jest.fn(),
+            get: jest.fn(),
           },
         },
       ],
@@ -47,5 +48,25 @@ describe('UsersService', () => {
       createdAt: expect.any(String),
       updatedAt: expect.any(String),
     });
+  });
+
+  it('should get store by id', async () => {
+    const userId = randomUUID();
+    const storeId = randomUUID();
+    const mockStore = {
+      id: storeId,
+      name: 'Store',
+      userId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    jest
+      .spyOn<any, any>(mockStoreService, 'get')
+      .mockImplementation(() => Promise.resolve(mockStore));
+
+    const store = await service.getStore(userId, storeId);
+    expect(mockStoreService.get).toHaveBeenCalledWith(userId, storeId);
+    expect(store).toMatchObject(mockStore);
   });
 });

--- a/src/user/service/user.service.ts
+++ b/src/user/service/user.service.ts
@@ -9,4 +9,7 @@ export class UserService {
 
   createStore = async (newStore: NewStoreModel): Promise<Store> =>
     this.storeService.create(newStore);
+
+  getStore = async (userId: string, storeId: string): Promise<Store> =>
+    this.storeService.get(userId, storeId);
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,7 +1,7 @@
-import { Controller, Post, Body, Param } from '@nestjs/common';
+import { Controller, Post, Body, Param, Get } from '@nestjs/common';
 import { UserService } from './service/user.service';
 import { CreateStoreDto } from '../store/dto/create-store.dto';
-import { ApiCreatedResponse } from '@nestjs/swagger';
+import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
 import { randomUUID } from 'crypto';
 
 @Controller()
@@ -31,6 +31,30 @@ export class UsersController {
       ...createStoreDto,
       userId,
     });
+    return { store };
+  }
+
+  @ApiOkResponse({
+    description: 'Store found',
+    schema: {
+      example: {
+        store: {
+          id: randomUUID(),
+          name: 'Store Name',
+          userId: randomUUID(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    },
+  })
+  @Get(':userId/store/:storeId')
+  async getStore(
+    @Param('userId') userId: string,
+    @Param('storeId') storeId: string,
+  ) {
+    const store = await this.usersService.getStore(userId, storeId);
+
     return { store };
   }
 }

--- a/test/store.e2e-spec.ts
+++ b/test/store.e2e-spec.ts
@@ -41,4 +41,51 @@ describe('StoreController (e2e)', () => {
         });
       });
   });
+
+  it('get store', async () => {
+    const userId = randomUUID();
+    const store = await prismadb.store.create({
+      data: {
+        id: randomUUID(),
+        name: 'store',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    return request(app.getHttpServer())
+      .get(`/api/user/${userId}/store/${store.id}`)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body).toMatchObject({
+          store: {
+            id: store.id,
+            name: 'store',
+            userId,
+            createdAt: store.createdAt.toISOString(),
+            updatedAt: store.updatedAt.toISOString(),
+          },
+        });
+
+        await prismadb.store.delete({
+          where: {
+            id: store.id,
+          },
+        });
+      });
+  });
+
+  it('return 404 if store not found', async () => {
+    const userId = randomUUID();
+    return request(app.getHttpServer())
+      .get(`/api/user/${userId}/store/${randomUUID()}`)
+      .expect(404)
+      .then(async (response) => {
+        expect(response.body).toMatchObject({
+          statusCode: 404,
+          message: 'Store not found',
+        });
+      });
+  });
 });


### PR DESCRIPTION
This pull request primarily introduces a new feature to the store service, allowing users to retrieve a store by its ID and the user's ID. The most significant changes involve adding a new `get` method to the `StoreRepository` and `StoreService` classes, updating the `UserService` to use this new method, and adding a new endpoint to the `UsersController` to expose this functionality. Additionally, tests have been added to ensure the correct behavior of these new features.

New feature implementation:

* `src/store/repository/prisma/prismaStore.repository.spec.ts`, `src/store/repository/prisma/prismaStore.repository.ts`: Added a `findFirst` method to the `PrismaStoreRepository` class, allowing the retrieval of a store by its ID and the user's ID. 
* [`src/store/repository/store.repository.ts`](diffhunk://#diff-1e008320fd2d3ebd7f63b1cecef30f8ccce4772b581d796065f9b67fecd4a13aR6-R7): Updated the `StoreRepository` interface to include the new `get` method.
* `src/store/service/store.service.spec.ts`, `src/store/service/store.service.ts`: Updated the `StoreService` class to include the new `get` method, which retrieves a store by its ID and the user's ID, and throws a `NotFoundException` if the store does not exist. 
* `src/user/service/user.service.spec.ts`, `src/user/service/user.service.ts`: Updated the `UserService` class to include a `getStore` method, which uses the `StoreService`'s `get` method to retrieve a store by its ID and the user's ID.

Test implementation:

* `src/store/repository/prisma/prismaStore.repository.spec.ts`, `src/store/service/store.service.spec.ts`, `src/user/service/user.service.spec.ts`, `test/store.e2e-spec.ts`: Added tests to ensure the correct behavior of the new `get` methods in the `StoreRepository`, `StoreService`, and `UserService` classes, as well as the new `GET` endpoint in the `UsersController`.