### PR TITLE
[feat]get stores by userId

### DIFF
--- a/src/store/repository/prisma/prismaStore.repository.spec.ts
+++ b/src/store/repository/prisma/prismaStore.repository.spec.ts
@@ -78,4 +78,26 @@ describe('PrismaStoreRepository', () => {
     });
     expect(store).toMatchObject(mockStore);
   });
+
+  it('should find store by userId', async () => {
+    const mockUserId = randomUUID();
+    const mockStore = {
+      id: randomUUID(),
+      name: 'Store',
+      userId: mockUserId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+    jest
+      .spyOn<any, any>(mockPrismaService.store, 'findFirst')
+      .mockImplementation(() => Promise.resolve(mockStore));
+
+    const store = await repository.getByUserId(mockUserId);
+    expect(mockPrismaService.store.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: mockUserId,
+      },
+    });
+    expect(store).toMatchObject(mockStore);
+  });
 });

--- a/src/store/repository/prisma/prismaStore.repository.ts
+++ b/src/store/repository/prisma/prismaStore.repository.ts
@@ -13,4 +13,7 @@ export class PrismaStoreRepository implements StoreRepository {
 
   get = async (userId: string, storeId: string): Promise<Store> =>
     this.prisma.store.findFirst({ where: { id: storeId, userId } });
+
+  getByUserId = async (userId: string): Promise<Store> =>
+    this.prisma.store.findFirst({ where: { userId } });
 }

--- a/src/store/repository/store.repository.ts
+++ b/src/store/repository/store.repository.ts
@@ -5,4 +5,6 @@ export abstract class StoreRepository {
   create: (newStore: NewStoreModel) => Promise<Store>;
 
   get: (userId: string, storeId: string) => Promise<Store>;
+
+  getByUserId: (userId: string) => Promise<Store>;
 }

--- a/src/store/service/store.service.spec.ts
+++ b/src/store/service/store.service.spec.ts
@@ -17,6 +17,7 @@ describe('StoreService', () => {
           useValue: {
             create: jest.fn(),
             get: jest.fn(),
+            getByUserId: jest.fn(),
           },
         },
       ],
@@ -79,6 +80,36 @@ describe('StoreService', () => {
       .mockImplementation(() => Promise.resolve(null));
 
     await expect(service.get(userId, storeId)).rejects.toThrow(
+      new NotFoundException('Store not found'),
+    );
+  });
+
+  it('get store by userId', async () => {
+    const userId = randomUUID();
+    const mockStore = {
+      id: randomUUID(),
+      name: 'Store',
+      userId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    jest
+      .spyOn<any, any>(mockStoreRepository, 'getByUserId')
+      .mockImplementation(() => Promise.resolve(mockStore));
+
+    const store = await service.getByUserId(userId);
+    expect(store).toMatchObject(mockStore);
+  });
+
+  it('throw error user does not have store', async () => {
+    const userId = randomUUID();
+
+    jest
+      .spyOn<any, any>(mockStoreRepository, 'getByUserId')
+      .mockImplementation(() => Promise.resolve(null));
+
+    await expect(service.getByUserId(userId)).rejects.toThrow(
       new NotFoundException('Store not found'),
     );
   });

--- a/src/store/service/store.service.ts
+++ b/src/store/service/store.service.ts
@@ -18,4 +18,14 @@ export class StoreService {
 
     return store;
   };
+
+  getByUserId = async (userId: string): Promise<Store> => {
+    const store = await this.storeRepository.getByUserId(userId);
+
+    if (!store) {
+      throw new NotFoundException('Store not found');
+    }
+
+    return store;
+  };
 }

--- a/src/user/service/user.service.spec.ts
+++ b/src/user/service/user.service.spec.ts
@@ -16,6 +16,7 @@ describe('UsersService', () => {
           useValue: {
             create: jest.fn(),
             get: jest.fn(),
+            getByUserId: jest.fn(),
           },
         },
       ],
@@ -67,6 +68,25 @@ describe('UsersService', () => {
 
     const store = await service.getStore(userId, storeId);
     expect(mockStoreService.get).toHaveBeenCalledWith(userId, storeId);
+    expect(store).toMatchObject(mockStore);
+  });
+
+  it('should get store by userId', async () => {
+    const userId = randomUUID();
+    const mockStore = {
+      id: randomUUID(),
+      name: 'Store',
+      userId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    jest
+      .spyOn<any, any>(mockStoreService, 'getByUserId')
+      .mockImplementation(() => Promise.resolve(mockStore));
+
+    const store = await service.getStoreByUserId(userId);
+    expect(mockStoreService.getByUserId).toHaveBeenCalledWith(userId);
     expect(store).toMatchObject(mockStore);
   });
 });

--- a/src/user/service/user.service.ts
+++ b/src/user/service/user.service.ts
@@ -12,4 +12,7 @@ export class UserService {
 
   getStore = async (userId: string, storeId: string): Promise<Store> =>
     this.storeService.get(userId, storeId);
+
+  getStoreByUserId = async (userId: string): Promise<Store> =>
+    this.storeService.getByUserId(userId);
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,7 +1,11 @@
 import { Controller, Post, Body, Param, Get } from '@nestjs/common';
 import { UserService } from './service/user.service';
 import { CreateStoreDto } from '../store/dto/create-store.dto';
-import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
+import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+} from '@nestjs/swagger';
 import { randomUUID } from 'crypto';
 
 @Controller()
@@ -48,12 +52,51 @@ export class UsersController {
       },
     },
   })
+  @ApiNotFoundResponse({
+    description: 'Store not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Store not found',
+      },
+    },
+  })
   @Get(':userId/store/:storeId')
   async getStore(
     @Param('userId') userId: string,
     @Param('storeId') storeId: string,
   ) {
     const store = await this.usersService.getStore(userId, storeId);
+
+    return { store };
+  }
+
+  @ApiOkResponse({
+    description: 'Store found',
+    schema: {
+      example: {
+        store: {
+          id: randomUUID(),
+          name: 'Store Name',
+          userId: randomUUID(),
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Store not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Store not found',
+      },
+    },
+  })
+  @Get(':userId/store')
+  async getStoreByUser(@Param('userId') userId: string) {
+    const store = await this.usersService.getStoreByUserId(userId);
 
     return { store };
   }

--- a/test/store.e2e-spec.ts
+++ b/test/store.e2e-spec.ts
@@ -88,4 +88,51 @@ describe('StoreController (e2e)', () => {
         });
       });
   });
+
+  it('get store by userId', async () => {
+    const userId = randomUUID();
+    const store = await prismadb.store.create({
+      data: {
+        id: randomUUID(),
+        name: 'store',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    return request(app.getHttpServer())
+      .get(`/api/user/${userId}/store`)
+      .expect(200)
+      .then(async (response) => {
+        expect(response.body).toMatchObject({
+          store: {
+            id: store.id,
+            name: 'store',
+            userId,
+            createdAt: store.createdAt.toISOString(),
+            updatedAt: store.updatedAt.toISOString(),
+          },
+        });
+
+        await prismadb.store.delete({
+          where: {
+            id: store.id,
+          },
+        });
+      });
+  });
+
+  it('return 404 if store not found by userId', async () => {
+    const userId = randomUUID();
+    return request(app.getHttpServer())
+      .get(`/api/user/${userId}/store`)
+      .expect(404)
+      .then(async (response) => {
+        expect(response.body).toMatchObject({
+          statusCode: 404,
+          message: 'Store not found',
+        });
+      });
+  });
 });


### PR DESCRIPTION
This pull request primarily introduces a new feature to the application, allowing users to find a store by a user's ID. This change affects several files across the codebase, including repository, service, and controller classes, as well as their corresponding test files. The changes are mainly concentrated around the addition of the `getByUserId` method and its usage.

New Feature Implementation:

* `src/store/repository/prisma/prismaStore.repository.spec.ts`, `src/store/repository/prisma/prismaStore.repository.ts`, `src/store/repository/store.repository.ts`: A new method `getByUserId` was added to the `PrismaStoreRepository` class and the `StoreRepository` abstract class, which allows finding a store by a user's ID. The corresponding test was also added. 

* `src/store/service/store.service.spec.ts`, `src/store/service/store.service.ts`: The `getByUserId` method was also added to the `StoreService` class, with the addition of error handling for cases when a store is not found. The corresponding test was also added.

* `src/user/service/user.service.spec.ts`, `src/user/service/user.service.ts`: The `getStoreByUserId` method was added to the `UserService` class, which uses the `getByUserId` method from `StoreService`. The corresponding test was also added.

* [`src/user/user.controller.ts`](diffhunk://#diff-8d9225643f0fb2cba6a02345b85424c6ce325e67c6512326c659b83e85ff57e5L4-R8): Two new endpoints were added to the `UsersController` class. The first one retrieves a store by a user's ID, and the second one retrieves a store by a store's ID and a user's ID. Both endpoints handle the case when a store is not found. 

* [`test/store.e2e-spec.ts`](diffhunk://#diff-216c437a97c2d867cf7fdd4547453fd8387efc0586aaa32bfcfc88f0fc4c3dd4R91-R137): Two new end-to-end tests were added. The first one tests the retrieval of a store by a user's ID, and the second one tests the error handling when a store is not found by a user's ID.