### PR TITLE
Add get stores

### DIFF
--- a/src/store/repository/prisma/prismaStore.repository.spec.ts
+++ b/src/store/repository/prisma/prismaStore.repository.spec.ts
@@ -17,6 +17,7 @@ describe('PrismaStoreRepository', () => {
             store: {
               create: jest.fn(),
               findFirst: jest.fn(),
+              findMany: jest.fn(),
             },
           },
         },
@@ -99,5 +100,27 @@ describe('PrismaStoreRepository', () => {
       },
     });
     expect(store).toMatchObject(mockStore);
+  });
+
+  it('should find all stores by userId', async () => {
+    const mockUserId = 'user_2fYgThng9k3ZvaPI7g9fRWOYrWi';
+    const mockStores = Array.from({ length: 3 }, (_, index) => ({
+      id: randomUUID(),
+      name: `Store ${index + 1}`,
+      userId: mockUserId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+    jest
+      .spyOn<any, any>(mockPrismaService.store, 'findMany')
+      .mockImplementation(() => Promise.resolve(mockStores));
+
+    const stores = await repository.getAllUserStores(mockUserId);
+    expect(mockPrismaService.store.findMany).toHaveBeenCalledWith({
+      where: {
+        userId: mockUserId,
+      },
+    });
+    expect(stores).toMatchObject(mockStores);
   });
 });

--- a/src/store/repository/prisma/prismaStore.repository.ts
+++ b/src/store/repository/prisma/prismaStore.repository.ts
@@ -16,4 +16,8 @@ export class PrismaStoreRepository implements StoreRepository {
 
   getByUserId = async (userId: string): Promise<Store> =>
     this.prisma.store.findFirst({ where: { userId } });
+
+  getAllUserStores = async (userId: string): Promise<Store[]> => {
+    return this.prisma.store.findMany({ where: { userId } });
+  };
 }

--- a/src/store/repository/store.repository.ts
+++ b/src/store/repository/store.repository.ts
@@ -7,4 +7,6 @@ export abstract class StoreRepository {
   get: (userId: string, storeId: string) => Promise<Store>;
 
   getByUserId: (userId: string) => Promise<Store>;
+
+  getAllUserStores: (userId: string) => Promise<Store[]>;
 }

--- a/src/store/service/store.service.spec.ts
+++ b/src/store/service/store.service.spec.ts
@@ -18,6 +18,7 @@ describe('StoreService', () => {
             create: jest.fn(),
             get: jest.fn(),
             getByUserId: jest.fn(),
+            getAllUserStores: jest.fn(),
           },
         },
       ],
@@ -111,6 +112,36 @@ describe('StoreService', () => {
 
     await expect(service.getByUserId(userId)).rejects.toThrow(
       new NotFoundException('Store not found'),
+    );
+  });
+
+  it('get all user stores', async () => {
+    const mockUserId = 'user_2fYgThng9k3ZvaPI7g9fRWOYrWi';
+    const mockStores = Array.from({ length: 3 }, (_, index) => ({
+      id: randomUUID(),
+      name: `Store ${index + 1}`,
+      userId: mockUserId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+
+    jest
+      .spyOn<any, any>(mockStoreRepository, 'getAllUserStores')
+      .mockImplementation(() => Promise.resolve(mockStores));
+
+    const stores = await service.getAllUserStores(mockUserId);
+    expect(stores).toMatchObject(mockStores);
+  });
+
+  it('throw error if user does not have stores', async () => {
+    const mockUserId = 'user_2fYgThng9k3ZvaPI7g9fRWOYrWi';
+
+    jest
+      .spyOn<any, any>(mockStoreRepository, 'getAllUserStores')
+      .mockImplementation(() => Promise.resolve([]));
+
+    await expect(service.getAllUserStores(mockUserId)).rejects.toThrow(
+      new NotFoundException('Stores not found'),
     );
   });
 });

--- a/src/store/service/store.service.spec.ts
+++ b/src/store/service/store.service.spec.ts
@@ -68,7 +68,7 @@ describe('StoreService', () => {
       .spyOn<any, any>(mockStoreRepository, 'get')
       .mockImplementation(() => Promise.resolve(mockStore));
 
-    const store = await service.get(storeId, userId);
+    const store = await service.get(userId, storeId);
     expect(store).toMatchObject(mockStore);
   });
 

--- a/src/store/service/store.service.ts
+++ b/src/store/service/store.service.ts
@@ -28,4 +28,14 @@ export class StoreService {
 
     return store;
   };
+
+  getAllUserStores = async (userId: string): Promise<Store[]> => {
+    const stores = await this.storeRepository.getAllUserStores(userId);
+
+    if (stores.length === 0) {
+      throw new NotFoundException('Stores not found');
+    }
+
+    return stores;
+  };
 }

--- a/src/user/service/user.service.spec.ts
+++ b/src/user/service/user.service.spec.ts
@@ -17,6 +17,7 @@ describe('UsersService', () => {
             create: jest.fn(),
             get: jest.fn(),
             getByUserId: jest.fn(),
+            getAllUserStores: jest.fn(),
           },
         },
       ],
@@ -88,5 +89,24 @@ describe('UsersService', () => {
     const store = await service.getStoreByUserId(userId);
     expect(mockStoreService.getByUserId).toHaveBeenCalledWith(userId);
     expect(store).toMatchObject(mockStore);
+  });
+
+  it('should get all user stores', async () => {
+    const mockUserId = 'user_2fYgThng9k3ZvaPI7g9fRWOYrWi';
+    const mockStores = Array.from({ length: 3 }, (_, index) => ({
+      id: randomUUID(),
+      name: `Store ${index + 1}`,
+      userId: mockUserId,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }));
+
+    jest
+      .spyOn<any, any>(mockStoreService, 'getAllUserStores')
+      .mockImplementation(() => Promise.resolve(mockStores));
+
+    const stores = await service.getAllUserStores(mockUserId);
+    expect(mockStoreService.getAllUserStores).toHaveBeenCalledWith(mockUserId);
+    expect(stores).toMatchObject(mockStores);
   });
 });

--- a/src/user/service/user.service.ts
+++ b/src/user/service/user.service.ts
@@ -15,4 +15,7 @@ export class UserService {
 
   getStoreByUserId = async (userId: string): Promise<Store> =>
     this.storeService.getByUserId(userId);
+
+  getAllUserStores = async (userId: string): Promise<Store[]> =>
+    this.storeService.getAllUserStores(userId);
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -100,4 +100,34 @@ export class UsersController {
 
     return { store };
   }
+
+  @ApiOkResponse({
+    description: 'Get all stores of with userId',
+    schema: {
+      example: {
+        stores: Array.from({ length: 3 }, (_, index) => ({
+          id: randomUUID(),
+          name: `Store ${index + 1}`,
+          userId: 'user_2fYgThng9k3ZvaPI7g9fRWOYrWi',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })),
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'Store not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'Store not found',
+      },
+    },
+  })
+  @Get(':userId/stores')
+  async getStoresByUser(@Param('userId') userId: string) {
+    const stores = await this.usersService.getAllUserStores(userId);
+
+    return { stores };
+  }
 }


### PR DESCRIPTION
This pull request primarily introduces a new feature that allows retrieving all stores associated with a specific user ID. This feature has been implemented across various layers of the application, including the repository, service, and controller levels. The changes also include the corresponding unit tests and end-to-end tests to ensure the feature's correctness.

Here are the most important changes:

**Repository Layer:**

* [`src/store/repository/prisma/prismaStore.repository.spec.ts`](diffhunk://#diff-03db65bbb182aaf9323e82effe3f35e8263f6bc9a32b93c9997df88bc1098c46R20): Added a new test case for the `getAllUserStores` method and mocked the `findMany` method of the `store` object. 
* [`src/store/repository/prisma/prismaStore.repository.ts`](diffhunk://#diff-a5bbe0f129d44f80d7158414d42875ccb5086a3c7cc63dcd76c07cf1c0167006R19-R22): Implemented the `getAllUserStores` method in the `PrismaStoreRepository` class.
* [`src/store/repository/store.repository.ts`](diffhunk://#diff-1e008320fd2d3ebd7f63b1cecef30f8ccce4772b581d796065f9b67fecd4a13aR10-R11): Added the `getAllUserStores` method to the `StoreRepository` abstract class.

**Service Layer:**

* [`src/store/service/store.service.spec.ts`](diffhunk://#diff-c9e335ca9a977a626aeb39dc0fe77cfe775c0ed0a24a48d8d54dec278947907cR21): Added new test cases for the `getAllUserStores` method and mocked the same method in the `StoreRepository` instance. Also, corrected the argument order in the `get` method call. 
* [`src/store/service/store.service.ts`](diffhunk://#diff-558cf6dfa606e171a3ec1f5225dc8f776e3eeaae90911f83e76e4b48338ee3b8R31-R40): Implemented the `getAllUserStores` method in the `StoreService` class. This method fetches all the stores associated with a user and throws a `NotFoundException` if no stores are found.
* [`src/user/service/user.service.spec.ts`](diffhunk://#diff-868fff0f1e389b88e995d7bcb969ae12ef3f9b52fc1cea2f2ee53b7ec37680d0R20): Added a new test case for the `getAllUserStores` method and mocked the same method in the `StoreService` instance. 
* [`src/user/service/user.service.ts`](diffhunk://#diff-2868e0a895feb68f632bd8b8b039046379a730564346b407a384bc6869489905R18-R20): Implemented the `getAllUserStores` method in the `UserService` class.

**Controller Layer:**

* [`src/user/user.controller.ts`](diffhunk://#diff-8d9225643f0fb2cba6a02345b85424c6ce325e67c6512326c659b83e85ff57e5R103-R132): Added a new route handler for `GET /:userId/stores` that retrieves all stores associated with a user ID.

**End-to-End Tests:**

* [`test/store.e2e-spec.ts`](diffhunk://#diff-216c437a97c2d867cf7fdd4547453fd8387efc0586aaa32bfcfc88f0fc4c3dd4R138-R186): Added new end-to-end tests for the `GET /:userId/stores` route. The tests cover the scenarios where the user has stores and where the user does not have any stores.