### PR TITLE
[test]create prismaService mock

### DIFF
--- a/src/__mocks__/prismaService.mock.ts
+++ b/src/__mocks__/prismaService.mock.ts
@@ -1,0 +1,82 @@
+import { Store } from '@prisma/client';
+import { randomUUID } from 'crypto';
+
+export class MockPrismaService {
+  db: Store[] = [];
+  store = {
+    create: (args: { data: { name: string; userId: string; id?: string } }) => {
+      const store = {
+        ...args.data,
+        id: args.data.id || randomUUID(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      this.db.push(store);
+      return {
+        ...store,
+        createdAt: store.createdAt.toISOString(),
+        updatedAt: store.updatedAt.toISOString(),
+      };
+    },
+    findFirst: (args: { where: any }) => {
+      const store = this.db.find((store) =>
+        Object.keys(args.where).every((key) => store[key] === args.where[key]),
+      );
+
+      return store
+        ? {
+            ...store,
+            createdAt: store.createdAt.toISOString(),
+            updatedAt: store.updatedAt.toISOString(),
+          }
+        : null;
+    },
+    findMany: (args: { where: any }) => {
+      const stores = this.db.filter((store) =>
+        Object.keys(args.where).every((key) => store[key] === args.where[key]),
+      );
+      return stores.length > 0
+        ? stores.map((store) => ({
+            ...store,
+            createdAt: store.createdAt.toISOString(),
+            updatedAt: store.updatedAt.toISOString(),
+          }))
+        : [];
+    },
+    update: (args: { where: any; data: any }) => {
+      const storeIndex = this.db.findIndex((store) =>
+        Object.keys(args.where).every((key) => store[key] === args.where[key]),
+      );
+
+      if (storeIndex === -1) return null;
+
+      const store = {
+        ...this.db[storeIndex],
+        ...args.data,
+      };
+      this.db[storeIndex] = store;
+
+      return {
+        ...store,
+        createdAt: store.createdAt.toISOString(),
+        updatedAt: store.updatedAt.toISOString(),
+      };
+    },
+    delete: (args: { where: any; data: any }) => {
+      const storeIndex = this.db.findIndex((store) =>
+        Object.keys(args.where).every((key) => store[key] === args.where[key]),
+      );
+
+      if (storeIndex === -1) return null;
+
+      const store = this.db[storeIndex];
+      this.db.splice(storeIndex, 1);
+
+      return {
+        ...store,
+        createdAt: store.createdAt.toISOString(),
+        updatedAt: store.updatedAt.toISOString(),
+      };
+    },
+  };
+}

--- a/src/__mocks__/prismaService.mock.ts
+++ b/src/__mocks__/prismaService.mock.ts
@@ -2,7 +2,8 @@ import { Store } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
 export class MockPrismaService {
-  db: Store[] = [];
+  private db: Store[] = [];
+  reset = () => this.db = [];
   store = {
     create: (args: { data: { name: string; userId: string; id?: string } }) => {
       const store = {

--- a/src/store/repository/prisma/prismaStore.repository.spec.ts
+++ b/src/store/repository/prisma/prismaStore.repository.spec.ts
@@ -21,6 +21,7 @@ describe('PrismaStoreRepository', () => {
 
     repository = module.get<PrismaStoreRepository>(PrismaStoreRepository);
     mockPrismaService = module.get<PrismaService>(PrismaService);
+    mockPrismaService['reset']()
   });
 
   it('should create store', async () => {


### PR DESCRIPTION
This pull request primarily focuses on refactoring the test suite for the `PrismaStoreRepository` in the `src/store/repository/prisma/prismaStore.repository.spec.ts` file. The changes involve replacing the mock implementation of `PrismaService` with a new `MockPrismaService` class defined in the `src/__mocks__/prismaService.mock.ts` file. This new class simulates a simple in-memory database and provides more realistic behavior for the methods of `PrismaService`. 

Here are the most important changes:

* [`src/__mocks__/prismaService.mock.ts`](diffhunk://#diff-675700e05c7df29969d89b93a195744a56aa7e7ac138e883c9613262da3d56e8R1-R82): Created a new `MockPrismaService` class, which simulates a simple in-memory database and provides methods to create, find, update, and delete records.

Changes to `src/store/repository/prisma/prismaStore.repository.spec.ts`:

* Replaced the mock implementation of `PrismaService` with an instance of `MockPrismaService`.
* Updated tests to use the methods of `MockPrismaService` instead of manually mocking the return values of these methods. This change makes the tests more realistic and reliable.
* Added assertions to check the state of the in-memory database after creating and deleting records. 