### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -7,6 +7,7 @@ on:
     workflows: ['lint', 'unit tests', 'integration tests']
     types:
       - completed
+
   push:
     branches:
       - main

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   stage:
     runs-on: ubuntu-latest
-
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: JorgeLNJunior/render-deploy@v1.3.2
         with:


### PR DESCRIPTION
This pull request includes a change to the `prod.yaml` file in the `.github/workflows` directory. The change adds a condition to the `stage` job to only run if the `workflow_run` event's `conclusion` is 'success'. This will ensure that the `stage` job only runs when all previous workflows (lint, unit tests, and integration tests) have successfully completed. 

* [`.github/workflows/prod.yaml`](diffhunk://#diff-03f59c3eb7c5333b88d711d25c3d161a0c51abf220732aef4f9ae00d0af09494R10-R18): Added a condition to the `stage` job to only run if the `workflow_run` event's `conclusion` is 'success'. This prevents the `stage` job from running if previous workflows have failed.